### PR TITLE
feat: follows logging standards in aind-log-utils

### DIFF
--- a/log_config_template.yaml
+++ b/log_config_template.yaml
@@ -1,0 +1,61 @@
+---
+version: 1
+disable_existing_loggers: false
+formatters:
+  default:
+    "()": aind_airflow_jobs.CustomJsonFormatter
+    format: "%(asctime)s %(levelname)s %(module)s %(lineno)s %(message)s"
+    reserved_attrs:
+      - args
+      - asctime
+      - created
+      - exc_info
+      - exc_text
+      - filename
+      - funcName
+      - levelname
+      - levelno
+      - lineno
+      - message
+      - module
+      - msecs
+      - msg
+      - name
+      - pathname
+      - process
+      - processName
+      - relativeCreated
+      - stack_info
+      - taskName
+      - thread
+      - threadName
+      - color_message
+    rename_fields:
+      "asctime": "timestamp"
+      "levelname": "level"
+    static_fields:
+      "environment": "local"
+      "software_version": ext://aind_airflow_jobs.__version__
+      "software_name": "aind-airflow-jobs"
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: default
+    level: INFO
+    stream: ext://sys.stdout
+loggers:
+  "":
+    handlers:
+      - console
+    level: INFO
+    propagate: true
+  uvicorn.error:
+    handlers:
+      - console
+    level: INFO
+    propagate: false
+  uvicorn.access:
+    handlers:
+      - console
+    level: INFO
+    propagate: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    "log-json",
-    "PyYAML>=6.0,<7.0",
     "pydantic-settings>=2.2.0,<3.0",
-    "pydantic>=2.2.0,<3.0"
+    "pydantic>=2.2.0,<3.0",
+    'python-json-logger',
+    "PyYAML>=6.0,<7.0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
+    "log-json",
+    "PyYAML>=6.0,<7.0",
     "pydantic-settings>=2.2.0,<3.0",
     "pydantic>=2.2.0,<3.0"
 ]

--- a/src/aind_airflow_jobs/__init__.py
+++ b/src/aind_airflow_jobs/__init__.py
@@ -1,3 +1,44 @@
-"""Package to manage airflow jobs"""
+"""Package to manage airflow jobs."""
+
+import logging
+import logging.config
+import os
+from datetime import datetime, timezone
+from logging import LogRecord
+
+import log_json
+import yaml
 
 __version__ = "0.4.2"
+
+
+# We want to standardize the timestamp format to UTC and ISO-8601, which
+# requires a custom formatter and cannot be done through configuration only.
+class CustomJsonFormatter(log_json.JsonFormatter):
+    """Custom class to format log timestamps as ISO-8601 UTC."""
+
+    def formatTime(self, record: LogRecord, datefmt=None) -> str:
+        """
+        Format timestamp as ISO-8601 UTC.
+
+        Parameters
+        ----------
+        record : LogRecord
+        datefmt : str, optional
+            Unused parameter, kept for signature compatibility.
+
+        Returns
+        -------
+        str
+
+        """
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+if os.path.isfile(os.getenv("LOGGING_CONFIG_FILE", "log_config.yaml")):
+    config_path = os.getenv("LOGGING_CONFIG_FILE", "log_config.yaml")
+    with open(config_path, "rt", encoding="utf-8") as f:
+        config = yaml.safe_load(f.read())
+    logging.config.dictConfig(config)
+    logging.info("Found logging file at: %s", config_path)

--- a/src/aind_airflow_jobs/__init__.py
+++ b/src/aind_airflow_jobs/__init__.py
@@ -6,8 +6,8 @@ import os
 from datetime import datetime, timezone
 from logging import LogRecord
 
-import log_json
 import yaml
+from pythonjsonlogger import json as log_json
 
 __version__ = "0.4.2"
 

--- a/src/aind_airflow_jobs/dag_tasks/base.py
+++ b/src/aind_airflow_jobs/dag_tasks/base.py
@@ -29,11 +29,20 @@ class DagTasks:
                 f"Task function '{task_id}' not found or not callable!"
             )
 
+        logging.info(
+            f"Task '{task_id}' starting.",
+            extra={
+                "process_name": task_id,
+                "pipeline_name": "airflow DAG",
+                "event_type": "stage_start",
+            },
+        )
         task_func()
         logging.info(
             f"Task '{task_id}' completed successfully!",
             extra={
                 "process_name": task_id,
                 "pipeline_name": "airflow DAG",
+                "event_type": "stage_complete",
             },
         )

--- a/src/aind_airflow_jobs/dag_tasks/base.py
+++ b/src/aind_airflow_jobs/dag_tasks/base.py
@@ -30,4 +30,10 @@ class DagTasks:
             )
 
         task_func()
-        logging.info(f"Task '{task_id}' completed successfully!")
+        logging.info(
+            f"Task '{task_id}' completed successfully!",
+            extra={
+                "process_name": task_id,
+                "pipeline_name": "airflow DAG",
+            },
+        )

--- a/src/aind_airflow_jobs/dag_tasks/base.py
+++ b/src/aind_airflow_jobs/dag_tasks/base.py
@@ -33,7 +33,6 @@ class DagTasks:
             f"Task '{task_id}' starting.",
             extra={
                 "process_name": task_id,
-                "pipeline_name": "airflow DAG",
                 "event_type": "stage_start",
             },
         )
@@ -42,7 +41,6 @@ class DagTasks:
             f"Task '{task_id}' completed successfully!",
             extra={
                 "process_name": task_id,
-                "pipeline_name": "airflow DAG",
                 "event_type": "stage_complete",
             },
         )

--- a/src/aind_airflow_jobs/dag_tasks/check_connections.py
+++ b/src/aind_airflow_jobs/dag_tasks/check_connections.py
@@ -30,8 +30,20 @@ class CheckConnectionsDag(DagTasks):
         ams_uri = os.getenv("AMS_URI")
         co_uri = os.getenv("CO_URI")
 
-        logging.info(f"default_transfer_settings: {default_transfer_settings}")
-        logging.info(f"ams_uri: {ams_uri}")
+        logging.info(
+            f"default_transfer_settings: {default_transfer_settings}",
+            extra={
+                "process_name": "check_param_store_connection",
+                "pipeline_name": "airflow DAG",
+            },
+        )
+        logging.info(
+            f"ams_uri: {ams_uri}",
+            extra={
+                "process_name": "check_param_store_connection",
+                "pipeline_name": "airflow DAG",
+            },
+        )
 
         if not default_transfer_settings:
             raise AssertionError(
@@ -66,7 +78,13 @@ class CheckConnectionsDag(DagTasks):
         settings = SlurmClientSettings()
         slurm_api = settings.create_api_client()
         response = slurm_api.slurm_v0040_get_ping()
-        logging.info(f"SLURM ping response: {response}")
+        logging.info(
+            f"SLURM ping response: {response}",
+            extra={
+                "process_name": "check_slurm_connection",
+                "pipeline_name": "airflow DAG",
+            },
+        )
 
     def check_vast_connection(self):
         """Check that airflow can read files from VAST."""
@@ -89,7 +107,11 @@ class CheckConnectionsDag(DagTasks):
         ssh_command_output = self.airflow_task_settings.task_input_str or ""
         decoded = base64.b64decode(ssh_command_output).decode("utf-8")
         logging.info(
-            f"SSH Command Output: {ssh_command_output}. Decoded: {decoded}"
+            f"SSH Command Output: {ssh_command_output}. Decoded: {decoded}",
+            extra={
+                "process_name": "check_hpc_connection",
+                "pipeline_name": "airflow DAG",
+            },
         )
 
         if decoded.strip() != "Hello World":

--- a/src/aind_airflow_jobs/dag_tasks/check_connections.py
+++ b/src/aind_airflow_jobs/dag_tasks/check_connections.py
@@ -34,14 +34,12 @@ class CheckConnectionsDag(DagTasks):
             f"default_transfer_settings: {default_transfer_settings}",
             extra={
                 "process_name": "check_param_store_connection",
-                "pipeline_name": "airflow DAG",
             },
         )
         logging.info(
             f"ams_uri: {ams_uri}",
             extra={
                 "process_name": "check_param_store_connection",
-                "pipeline_name": "airflow DAG",
             },
         )
 
@@ -82,7 +80,6 @@ class CheckConnectionsDag(DagTasks):
             f"SLURM ping response: {response}",
             extra={
                 "process_name": "check_slurm_connection",
-                "pipeline_name": "airflow DAG",
             },
         )
 
@@ -110,7 +107,6 @@ class CheckConnectionsDag(DagTasks):
             f"SSH Command Output: {ssh_command_output}. Decoded: {decoded}",
             extra={
                 "process_name": "check_hpc_connection",
-                "pipeline_name": "airflow DAG",
             },
         )
 

--- a/src/aind_airflow_jobs/handlers/alert_handler.py
+++ b/src/aind_airflow_jobs/handlers/alert_handler.py
@@ -86,4 +86,13 @@ def send_log_message(
     level = level_name if isinstance(level_name, int) else logging.INFO
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.INFO)
-    logger.log(level, sanitized_message)
+    logger.log(
+        level,
+        sanitized_message,
+        extra={
+            "acquisition_name": job_name,
+            "process_name": task_id,
+            "pipeline_name": "airflow DAG",
+            "run_id": run_id,
+        },
+    )

--- a/src/aind_airflow_jobs/handlers/alert_handler.py
+++ b/src/aind_airflow_jobs/handlers/alert_handler.py
@@ -92,7 +92,6 @@ def send_log_message(
         extra={
             "acquisition_name": job_name,
             "process_name": task_id,
-            "pipeline_name": "airflow DAG",
             "run_id": run_id,
         },
     )

--- a/src/aind_airflow_jobs/handlers/slurm_v2_handler.py
+++ b/src/aind_airflow_jobs/handlers/slurm_v2_handler.py
@@ -350,7 +350,6 @@ class SubmitSlurmJobArray:
                         f"Restart count: {restart_count}",
                         extra={
                             "process_name": "submit_slurm_job_array",
-                            "pipeline_name": "airflow DAG",
                             "job_id": job_id_to_retry,
                             "job_state": job.job_state,
                         },
@@ -473,7 +472,6 @@ class SubmitSlurmJobArray:
             f"Initialized placeholder: {job_response}",
             extra={
                 "process_name": "monitor_slurm_job",
-                "pipeline_name": "airflow DAG",
                 "acquisition_name": job_name,
                 "job_id": job_id,
             },
@@ -485,7 +483,6 @@ class SubmitSlurmJobArray:
                 "Looking for job info in database...",
                 extra={
                     "process_name": "monitor_slurm_job",
-                    "pipeline_name": "airflow DAG",
                     "acquisition_name": job_name,
                     "job_id": job_id,
                 },
@@ -535,7 +532,6 @@ class SubmitSlurmJobArray:
             message,
             extra={
                 "process_name": "monitor_slurm_job",
-                "pipeline_name": "airflow DAG",
                 "acquisition_name": job_name,
                 "job_id": job_id,
             },
@@ -577,7 +573,6 @@ class SubmitSlurmJobArray:
                 message,
                 extra={
                     "process_name": "monitor_slurm_job",
-                    "pipeline_name": "airflow DAG",
                     "acquisition_name": job_name,
                     "job_id": job_id,
                 },
@@ -604,7 +599,6 @@ class SubmitSlurmJobArray:
                 f"std_err:\n{std_err_msg}",
                 extra={
                     "process_name": "monitor_slurm_job",
-                    "pipeline_name": "airflow DAG",
                     "acquisition_name": job_name,
                     "job_id": job_id,
                 },
@@ -619,7 +613,6 @@ class SubmitSlurmJobArray:
                 "Job is Finished!",
                 extra={
                     "process_name": "monitor_slurm_job",
-                    "pipeline_name": "airflow DAG",
                     "acquisition_name": job_name,
                     "job_id": job_id,
                 },
@@ -653,7 +646,6 @@ class SubmitSlurmJobArray:
             f"Job Name: {job_name}",
             extra={
                 "process_name": "run_slurm_job",
-                "pipeline_name": "airflow DAG",
                 "acquisition_name": job_name,
                 "job_id": job_id,
                 "event_type": "stage_start",
@@ -663,7 +655,6 @@ class SubmitSlurmJobArray:
             f"Job ID: {job_id}",
             extra={
                 "process_name": "run_slurm_job",
-                "pipeline_name": "airflow DAG",
                 "acquisition_name": job_name,
                 "job_id": job_id,
             },
@@ -673,7 +664,6 @@ class SubmitSlurmJobArray:
             f"Please check {std_err} for additional logs.",
             extra={
                 "process_name": "run_slurm_job",
-                "pipeline_name": "airflow DAG",
                 "acquisition_name": job_name,
                 "job_id": job_id,
             },
@@ -683,7 +673,6 @@ class SubmitSlurmJobArray:
             f"Job '{job_name}' completed successfully!",
             extra={
                 "process_name": "run_slurm_job",
-                "pipeline_name": "airflow DAG",
                 "acquisition_name": job_name,
                 "job_id": job_id,
                 "event_type": "stage_complete",
@@ -749,7 +738,6 @@ class SlurmJobSensor:
                         f"Restart count: {restart_count}",
                         extra={
                             "process_name": "slurm_job_sensor",
-                            "pipeline_name": "airflow DAG",
                             "job_id": job_id_to_retry,
                             "job_state": job.job_state,
                         },
@@ -850,7 +838,6 @@ class SlurmJobSensor:
                     f"std_err:\n{std_err_msg}",
                     extra={
                         "process_name": "slurm_job_sensor",
-                        "pipeline_name": "airflow DAG",
                         "job_id": self.job_id,
                     },
                 )
@@ -865,7 +852,6 @@ class SlurmJobSensor:
                 "Looking for job info in database...",
                 extra={
                     "process_name": "slurm_job_sensor",
-                    "pipeline_name": "airflow DAG",
                     "job_id": job_id,
                 },
             )

--- a/src/aind_airflow_jobs/handlers/slurm_v2_handler.py
+++ b/src/aind_airflow_jobs/handlers/slurm_v2_handler.py
@@ -656,6 +656,7 @@ class SubmitSlurmJobArray:
                 "pipeline_name": "airflow DAG",
                 "acquisition_name": job_name,
                 "job_id": job_id,
+                "event_type": "stage_start",
             },
         )
         logging.info(
@@ -678,6 +679,16 @@ class SubmitSlurmJobArray:
             },
         )
         self._monitor_job(submit_response=submit_response)
+        logging.info(
+            f"Job '{job_name}' completed successfully!",
+            extra={
+                "process_name": "run_slurm_job",
+                "pipeline_name": "airflow DAG",
+                "acquisition_name": job_name,
+                "job_id": job_id,
+                "event_type": "stage_complete",
+            },
+        )
 
 
 class SlurmJobSensor:

--- a/src/aind_airflow_jobs/handlers/slurm_v2_handler.py
+++ b/src/aind_airflow_jobs/handlers/slurm_v2_handler.py
@@ -347,7 +347,13 @@ class SubmitSlurmJobArray:
                     )
                     logging.warning(
                         f"Restarting {job.job_state} job: {job_id_to_retry}. "
-                        f"Restart count: {restart_count}"
+                        f"Restart count: {restart_count}",
+                        extra={
+                            "process_name": "submit_slurm_job_array",
+                            "pipeline_name": "airflow DAG",
+                            "job_id": job_id_to_retry,
+                            "job_state": job.job_state,
+                        },
                     )
                     sleep(1)
                     command = f"scontrol requeue {job_id_to_retry}"
@@ -463,11 +469,27 @@ class SubmitSlurmJobArray:
             last_backfill=V0040Uint64NoVal(),
             last_update=V0040Uint64NoVal(),
         )
-        logging.debug(f"Initialized placeholder: {job_response}")
+        logging.debug(
+            f"Initialized placeholder: {job_response}",
+            extra={
+                "process_name": "monitor_slurm_job",
+                "pipeline_name": "airflow DAG",
+                "acquisition_name": job_name,
+                "job_id": job_id,
+            },
+        )
         try:
             job_response = self.slurm.slurm_v0040_get_job(job_id=str(job_id))
         except NotFoundException:
-            logging.warning("Looking for job info in database...")
+            logging.warning(
+                "Looking for job info in database...",
+                extra={
+                    "process_name": "monitor_slurm_job",
+                    "pipeline_name": "airflow DAG",
+                    "acquisition_name": job_name,
+                    "job_id": job_id,
+                },
+            )
             slurm_db_api = SlurmdbApi(api_client=self.slurm.api_client)
             slurm_db_response = slurm_db_api.slurmdb_v0040_get_job(
                 job_id=str(job_id)
@@ -509,7 +531,15 @@ class SubmitSlurmJobArray:
                 "start_time": start_time,
             }
         )
-        logging.info(message)
+        logging.info(
+            message,
+            extra={
+                "process_name": "monitor_slurm_job",
+                "pipeline_name": "airflow DAG",
+                "acquisition_name": job_name,
+                "job_id": job_id,
+            },
+        )
         job_status = dict()
         is_finished, is_error = self._check_job_status(
             job_response, job_status
@@ -543,7 +573,15 @@ class SubmitSlurmJobArray:
                     "start_time": start_time,
                 }
             )
-            logging.info(message)
+            logging.info(
+                message,
+                extra={
+                    "process_name": "monitor_slurm_job",
+                    "pipeline_name": "airflow DAG",
+                    "acquisition_name": job_name,
+                    "job_id": job_id,
+                },
+            )
             is_finished, is_error = self._check_job_status(
                 job_response, job_status
             )
@@ -562,14 +600,30 @@ class SubmitSlurmJobArray:
                 remote_mnt_dir=self.remote_mnt_dir,
                 local_mnt_dir=self.local_mnt_dir,
             )
-            logging.exception(f"std_err:\n{std_err_msg}")
+            logging.exception(
+                f"std_err:\n{std_err_msg}",
+                extra={
+                    "process_name": "monitor_slurm_job",
+                    "pipeline_name": "airflow DAG",
+                    "acquisition_name": job_name,
+                    "job_id": job_id,
+                },
+            )
             raise Exception(
                 f"There were errors with the slurm job. "
                 f"Job: {message}. "
                 f"Errors: {errors}"
             )
         else:
-            logging.info("Job is Finished!")
+            logging.info(
+                "Job is Finished!",
+                extra={
+                    "process_name": "monitor_slurm_job",
+                    "pipeline_name": "airflow DAG",
+                    "acquisition_name": job_name,
+                    "job_id": job_id,
+                },
+            )
         return start_time, end_time
 
     def _std_err_filepath(self, job_id: Union[int, str]) -> str:
@@ -595,10 +649,34 @@ class SubmitSlurmJobArray:
         submit_response = self._submit_job()
         job_id = submit_response.job_id
         job_name = self.job_properties.name
-        logging.info(f"Job Name: {job_name}")
-        logging.info(f"Job ID: {job_id}")
+        logging.info(
+            f"Job Name: {job_name}",
+            extra={
+                "process_name": "run_slurm_job",
+                "pipeline_name": "airflow DAG",
+                "acquisition_name": job_name,
+                "job_id": job_id,
+            },
+        )
+        logging.info(
+            f"Job ID: {job_id}",
+            extra={
+                "process_name": "run_slurm_job",
+                "pipeline_name": "airflow DAG",
+                "acquisition_name": job_name,
+                "job_id": job_id,
+            },
+        )
         std_err = self._std_err_filepath(job_id=job_id)
-        logging.info(f"Please check {std_err} for additional logs.")
+        logging.info(
+            f"Please check {std_err} for additional logs.",
+            extra={
+                "process_name": "run_slurm_job",
+                "pipeline_name": "airflow DAG",
+                "acquisition_name": job_name,
+                "job_id": job_id,
+            },
+        )
         self._monitor_job(submit_response=submit_response)
 
 
@@ -657,7 +735,13 @@ class SlurmJobSensor:
                     )
                     logging.warning(
                         f"Restarting {job.job_state} job: {job_id_to_retry}. "
-                        f"Restart count: {restart_count}"
+                        f"Restart count: {restart_count}",
+                        extra={
+                            "process_name": "slurm_job_sensor",
+                            "pipeline_name": "airflow DAG",
+                            "job_id": job_id_to_retry,
+                            "job_state": job.job_state,
+                        },
                     )
                     sleep(1)
                     command = f"scontrol requeue {job_id_to_retry}"
@@ -751,7 +835,14 @@ class SlurmJobSensor:
                     remote_mnt_dir=self.remote_mnt_dir,
                     local_mnt_dir=self.local_mnt_dir,
                 )
-                logging.exception(f"std_err:\n{std_err_msg}")
+                logging.exception(
+                    f"std_err:\n{std_err_msg}",
+                    extra={
+                        "process_name": "slurm_job_sensor",
+                        "pipeline_name": "airflow DAG",
+                        "job_id": self.job_id,
+                    },
+                )
                 raise Exception(
                     f"There were errors with the slurm job. "
                     f"Job: {self.job_id}. "
@@ -759,7 +850,14 @@ class SlurmJobSensor:
                 )
             return is_finished, start_time, end_time
         except NotFoundException:
-            logging.warning("Looking for job info in database...")
+            logging.warning(
+                "Looking for job info in database...",
+                extra={
+                    "process_name": "slurm_job_sensor",
+                    "pipeline_name": "airflow DAG",
+                    "job_id": job_id,
+                },
+            )
             slurm_db_api = SlurmdbApi(api_client=self.slurm.api_client)
             slurm_db_response = slurm_db_api.slurmdb_v0040_get_job(
                 job_id=str(job_id)

--- a/src/aind_airflow_jobs/handlers/task_handler.py
+++ b/src/aind_airflow_jobs/handlers/task_handler.py
@@ -74,7 +74,6 @@ def get_merged_task_settings(
         f"Job type settings keys: {sorted(list(preset_task.keys()))}",
         extra={
             "process_name": task_id,
-            "pipeline_name": "airflow DAG",
             "job_type": job_type,
             "modality_abbreviation": modality_abbreviation,
         },
@@ -83,7 +82,6 @@ def get_merged_task_settings(
         f"User settings keys: {sorted(list(user_task.keys()))}",
         extra={
             "process_name": task_id,
-            "pipeline_name": "airflow DAG",
             "job_type": job_type,
             "modality_abbreviation": modality_abbreviation,
         },
@@ -93,7 +91,6 @@ def get_merged_task_settings(
         f"Merged settings keys: {sorted(list(preset_task.keys()))}",
         extra={
             "process_name": task_id,
-            "pipeline_name": "airflow DAG",
             "job_type": job_type,
             "modality_abbreviation": modality_abbreviation,
         },

--- a/src/aind_airflow_jobs/handlers/task_handler.py
+++ b/src/aind_airflow_jobs/handlers/task_handler.py
@@ -70,10 +70,34 @@ def get_merged_task_settings(
                 deserialize_json=True,
             )
 
-    logging.info(f"Job type settings: {preset_task}")
-    logging.info(f"User settings: {user_task}")
+    logging.info(
+        f"Job type settings keys: {sorted(list(preset_task.keys()))}",
+        extra={
+            "process_name": task_id,
+            "pipeline_name": "airflow DAG",
+            "job_type": job_type,
+            "modality_abbreviation": modality_abbreviation,
+        },
+    )
+    logging.info(
+        f"User settings keys: {sorted(list(user_task.keys()))}",
+        extra={
+            "process_name": task_id,
+            "pipeline_name": "airflow DAG",
+            "job_type": job_type,
+            "modality_abbreviation": modality_abbreviation,
+        },
+    )
     nested_update(preset_task, user_task)
-    logging.info(f"Merged settings: {preset_task}")
+    logging.info(
+        f"Merged settings keys: {sorted(list(preset_task.keys()))}",
+        extra={
+            "process_name": task_id,
+            "pipeline_name": "airflow DAG",
+            "job_type": job_type,
+            "modality_abbreviation": modality_abbreviation,
+        },
+    )
     return preset_task
 
 

--- a/tests/dag_tasks/test_base.py
+++ b/tests/dag_tasks/test_base.py
@@ -28,7 +28,10 @@ class TestDagTasks(unittest.TestCase):
 
         mock_task.assert_called_once()
         self.assertEqual(
-            ["INFO:root:Task 'task_1' completed successfully!"],
+            [
+                "INFO:root:Task 'task_1' starting.",
+                "INFO:root:Task 'task_1' completed successfully!",
+            ],
             captured.output,
         )
 

--- a/tests/handlers/test_alert_handler.py
+++ b/tests/handlers/test_alert_handler.py
@@ -68,6 +68,12 @@ class TestMethods(unittest.TestCase):
         mock_log.assert_called_once_with(
             10,
             "ecephys_123456_2020-10-10_10-10-10 on abc-123 and def-456: Hello",
+            extra={
+                "acquisition_name": "ecephys_123456_2020-10-10_10-10-10",
+                "process_name": "def-456",
+                "pipeline_name": "airflow DAG",
+                "run_id": "abc-123",
+            },
         )
 
 

--- a/tests/handlers/test_alert_handler.py
+++ b/tests/handlers/test_alert_handler.py
@@ -71,7 +71,6 @@ class TestMethods(unittest.TestCase):
             extra={
                 "acquisition_name": "ecephys_123456_2020-10-10_10-10-10",
                 "process_name": "def-456",
-                "pipeline_name": "airflow DAG",
                 "run_id": "abc-123",
             },
         )

--- a/tests/handlers/test_slurm_v2_handler.py
+++ b/tests/handlers/test_slurm_v2_handler.py
@@ -3,7 +3,7 @@
 import os
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 from aind_slurm_rest_v2 import (
     V0040Job,
@@ -640,17 +640,20 @@ class TestSubmitSlurmJobArray(unittest.TestCase):
             [
                 call(
                     '{"job_id": 12345, "job_name": "job_123", '
-                    '"job_states": ["PENDING"], "start_time": null}'
+                    '"job_states": ["PENDING"], "start_time": null}',
+                    extra=ANY,
                 ),
                 call(
                     '{"job_id": 12345, "job_name": "job_123", '
-                    '"job_states": ["RUNNING"], "start_time": 1693788400}'
+                    '"job_states": ["RUNNING"], "start_time": 1693788400}',
+                    extra=ANY,
                 ),
                 call(
                     '{"job_id": 12345, "job_name": "job_123", '
-                    '"job_states": ["COMPLETED"], "start_time": 1693788400}'
+                    '"job_states": ["COMPLETED"], "start_time": 1693788400}',
+                    extra=ANY,
                 ),
-                call("Job is Finished!"),
+                call("Job is Finished!", extra=ANY),
             ]
         )
 
@@ -740,18 +743,22 @@ class TestSubmitSlurmJobArray(unittest.TestCase):
         )
         self.assertEqual(expected_error_message, e.exception.args[0])
 
-        mock_log_exception.assert_called_once_with("std_err:\nError")
+        mock_log_exception.assert_called_once_with(
+            "std_err:\nError", extra=ANY
+        )
         mock_sleep.assert_has_calls([call(120)])
 
         mock_log_info.assert_has_calls(
             [
                 call(
                     '{"job_id": 12345, "job_name": "job_123", '
-                    '"job_states": ["RUNNING"], "start_time": null}'
+                    '"job_states": ["RUNNING"], "start_time": null}',
+                    extra=ANY,
                 ),
                 call(
                     '{"job_id": 12345, "job_name": "job_123", '
-                    '"job_states": ["FAILED"], "start_time": 1693788400}'
+                    '"job_states": ["FAILED"], "start_time": 1693788400}',
+                    extra=ANY,
                 ),
             ]
         )


### PR DESCRIPTION
closes #25 and https://github.com/AllenNeuralDynamics/aind-scientific-computing/issues/665

This PR:
- adds log config + json custom formatter
- adds `extra` to all logging steps that follow aind-log-utils (adds `process_name`, `pipeline_name`, etc)
- emits `event_type = stage_start | stage_complete | stage_failure`